### PR TITLE
fix duplicate property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Issuers submit data using an SEC Form ABS-EE ([example](https://www.sec.gov/Arch
 This project extracts data from EX-102 exhibits for Commercial Mortgage Backed Securities (CMBS) and stores it in an ElasticSearch index.  It creates one document for each property and geocodes its street address.
 
 Use the elasticSearchMapping.json file to create mappings for the index:
-`curl -X PUT http://localhost:9200/cmbs -d @elasticSearchMapping.json  -H 'Content-Type: application/json' `
+`curl -X PUT http://localhost:9200/cmbs -d @elasticSearch/elasticSearchMapping.json  -H 'Content-Type: application/json' `
 
 Edit php/src/PropertyGeospatial.php to add a [Google Geocoding API key](https://developers.google.com/maps/documentation/geocoding/get-api-key):
 

--- a/angular/cmbs-property-summary/src/app/constants.ts
+++ b/angular/cmbs-property-summary/src/app/constants.ts
@@ -1,2 +1,3 @@
 export const GOOGLE_MAPS_APIKEY: string = 'AIzaSyBMD21JpmlHER9Cdvi3mrA0vw8yQ6U5xS4';
-export const API_BASE_URL: string = 'https://api.visulate.net/';
+//export const API_BASE_URL: string = 'https://api.visulate.net/';
+export const API_BASE_URL: string = 'http://localhost/';

--- a/elasticSearch/README.md
+++ b/elasticSearch/README.md
@@ -1,0 +1,27 @@
+# Patches and Updates
+
+## Update ElasticSearch version on Mac
+
+1.  Download and unzip latest zipfile
+2.  Stop elasticSearch
+3.  Copy data directory
+4.  cd to new directory
+5.  ES_JAVA_OPTS="-XX:-MaxFDLimit" ./bin/elasticsearch
+
+## Update 1 - Fix duplicate property names and remove trailing spaces from use types
+
+```
+curl -X PUT http://localhost:9200/cmbs2 -d @elasticSearchMapping.json  -H 'Content-Type: application/json'
+
+curl -X POST "localhost:9200/_reindex" -H 'Content-Type: application/json' -d'
+{
+  "source": {
+    "index": "cmbs"
+  },
+  "dest": {
+    "index": "cmbs2"
+  }
+}
+'
+
+```

--- a/elasticSearch/elasticSearchMapping.json
+++ b/elasticSearch/elasticSearchMapping.json
@@ -1,4 +1,15 @@
 {
+  "settings": {
+    "analysis": {
+      "normalizer": {
+        "uppercase_trim": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["uppercase", "asciifolding", "trim"]
+        }
+      }
+    }
+  },  
   "mappings": {
     "filing": {
       "dynamic": "strict",
@@ -8,8 +19,8 @@
         "depositor_cik": {"type": "keyword"},
         "sponsor_cik": {"type": "keyword"},
         "issuing_entity_cik": {"type": "keyword"},
-        "depositor_name": {"type": "keyword"},
-        "issuing_entity_name": {"type": "keyword"},
+        "depositor_name": {"type": "keyword", "normalizer": "uppercase_trim"},
+        "issuing_entity_name": {"type": "keyword", "normalizer": "uppercase_trim"},
         "absEeUrl": {"type": "keyword"},
         "filingUrl": {"type": "keyword"},
         "sponsor_file_no": {"type": "keyword"},
@@ -120,13 +131,13 @@
         "property": {
           "dynamic": "strict",
           "properties": {
-            "propertyName": { "type": "keyword"},
+            "propertyName": { "type": "keyword", "normalizer": "uppercase_trim"},
             "propertyAddress": { "type": "text"},
             "propertyCity": { "type": "keyword"},
             "propertyState": { "type": "keyword"},
             "propertyZip": { "type": "keyword"},
             "propertyCounty": { "type": "keyword"},
-            "propertyTypeCode": { "type": "keyword"},
+            "propertyTypeCode": { "type": "keyword", "normalizer": "uppercase_trim"},
             "netRentableSquareFeetNumber": { "type": "integer"},
             "netRentableSquareFeetSecuritizationNumber": { "type": "integer"},
             "unitsBedsRoomsNumber": { "type": "integer"},

--- a/php/src/CmbsAssetDisplay.php
+++ b/php/src/CmbsAssetDisplay.php
@@ -321,6 +321,7 @@ class CmbsAssetDisplay {
                 'CT' => 'Connecticut',
                 'DE' => 'Delaware',
                 'DC' => 'District Of Columbia',
+                'E9' => 'Cayman Islands',
                 'FL' => 'Florida',
                 'GA' => 'Georgia',
                 'HI' => 'Hawaii',

--- a/php/src/ElasticSearchClient.php
+++ b/php/src/ElasticSearchClient.php
@@ -15,7 +15,7 @@ use Elasticsearch\ClientBuilder;
 class ElasticSearchClient {
     private $_client;
     
-    const ES_INDEX = 'cmbs';
+    const ES_INDEX = 'cmbs2';
     const ES_TYPE = 'filing';
     const ES_HOSTS = ['localhost:9200'];
     

--- a/php/tests/ElasticSearchQueriesTest.php
+++ b/php/tests/ElasticSearchQueriesTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) Visulate LLC 2018 All rights reserved
+ */
+
+use PHPUnit\Framework\TestCase;
+use CMBS\ElasticSearchQueries;
+
+class ElasticSearchQueriesTest extends TestCase {
+    protected static $query;
+    
+    public static function setUpBeforeClass()
+    {
+        self::$query = new ElasticSearchQueries();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$query = null;
+    }
+    
+   public function testGetUsSummary() {
+       print "\n Testing getUsSummary()\n";
+       $stateList = ['AK', 'AL', 'AR', 'AZ', 'CA', 'CI', 'CO', 'CT', 'DC', 'DE', 'E9', 
+           'FL', 'GA', 'HI', 'IA', 'ID', 'IL', 'IN', 'KS', 'KY', 'LA', 'MA', 'MD', 'ME', 
+           'MI', 'MN', 'MO', 'MS', 'MT', 'MX', 'NA', 'NC', 'ND', 'NE', 'NH', 'NJ', 'NM', 
+           'NV', 'NY', 'OH', 'OK', 'OR', 'PA', 'PN', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 
+           'UT', 'VA'];  // (E9 = 'Cayman Islands', NA = 'Not Available')
+       
+       $propTypes = ["CH", "HC", "IN", "LO", "MF", "MH", "MU", "OF", "RT", "SE", "SS", "WH", "ZZ", "98"];
+       
+       $response= self::$query->getUsSummary();
+       $this->assertEquals(count($response["aggregations"]["group_by_state"]["buckets"]), 52);
+       $errorCount = 0;
+       foreach ($response["aggregations"]["group_by_state"]["buckets"] as $state) {
+            $this->assertContains($state["key"], $stateList);
+           
+            foreach ($state["group_by_type"]["buckets"] as $usage) {
+                try {
+                    $this->assertContains($usage["key"], $propTypes);
+                } catch (Exception $e) {
+                    print "'" . $state["key"] . "/" . $usage["key"] . "': " . $e;
+                    $errorCount += 1;
+                }
+            }
+            
+        }
+        $this->assertEquals(0, $errorCount);
+    }
+    
+    public function testGetTypeSummaryNotCaseSensitive() {
+        print "\n Testing getTypeSummary()\n";
+        $response= self::$query->getTypeSummary('FL', 'OF');
+        $propNames = array();
+        $errorCount = 0;
+        foreach ($response["aggregations"]["property_name"]["buckets"] as $property){
+            if (array_key_exists(strtoupper($property["key"]), $propNames)){
+                print "\nDuplicate property name ". $property["key"] . " already indexed in ";
+                print_r($propNames);
+                $this->assertFalse("Duplicate properties");
+            }
+           $propNames[strtoupper($property["key"])] = $property["key"];
+        }
+        $this->assertEquals(0, $errorCount);
+    }
+    
+    
+}

--- a/php/tests/PropertyGeospatialTest.php
+++ b/php/tests/PropertyGeospatialTest.php
@@ -16,6 +16,7 @@ class PropertyGeospatialTest extends TestCase{
     
     
     public function testTigerLineCoords() {
+        print "\n Testing getTigerLineCoordinates()\n";
 
         $response = PropertyGeospatial::getTigerLineCoordinates("451 Seventh Avenue South", "Kirkland", "WA", "98033");
         print_r($response);
@@ -25,6 +26,7 @@ class PropertyGeospatialTest extends TestCase{
     }
     
     public function testGeocodeProperty() {
+         print "\n Testing geocodeProperty()\n";
         $geo = PropertyGeospatial::geocodeProperty("451 Seventh Avenue South", "Kirkland", "WA", "98033");
 
         $this->assertGreaterThan($geo['lon'], -122);
@@ -35,6 +37,7 @@ class PropertyGeospatialTest extends TestCase{
     }
     
     public function testGeocodeAssetProperty() {
+        print "\n Testing geocodeAssetProperty()\n";
         $property = [
             'propertyName' => 'Show Low Retail',
             'propertyAddress' => '5551 South White Mountain Road',

--- a/php/tests/RestApisTest.php
+++ b/php/tests/RestApisTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) Visulate LLC 2018 All rights reserved
+ */
+
+use PHPUnit\Framework\TestCase;
+use CMBS\RestApis;
+
+class RestApisTest extends TestCase {
+    protected static $restApis;
+    
+    public static function setUpBeforeClass()
+    {
+        self::$restApis = new RestApis();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$restApis = null;
+    }
+    
+    public function testGetCapRate() {
+        print "\n Testing getCapRate\n";
+        $capRate = self::$restApis->getCapRate(300000, 3000000);
+        $this->assertEquals($capRate, 10);
+        
+        $capRate2 = self::$restApis->getCapRate(0, 3000000);
+        $this->assertNull($capRate2);
+    }
+    
+    
+    
+}


### PR DESCRIPTION
Fixes issue where same property is returned twice if upper and lower case versions of the property name have been used.  Also trims trailing spaces from usage type code